### PR TITLE
Add file path to SITL instructions for Windows Users

### DIFF
--- a/docs/docs/user-guide/sitl.md
+++ b/docs/docs/user-guide/sitl.md
@@ -16,7 +16,8 @@ SITL runs Astra natively on your PC and connects to a simulator over TCP.
    pio run -e native
    ```
 
-3. Run the program:
+3. Run the program: <br/>
+   
    If you're on Linux/MacOS:
    ```bash
    .pio/build/native/program.exe

--- a/docs/docs/user-guide/sitl.md
+++ b/docs/docs/user-guide/sitl.md
@@ -17,9 +17,15 @@ SITL runs Astra natively on your PC and connects to a simulator over TCP.
    ```
 
 3. Run the program:
+   If you're on Linux/MacOS:
    ```bash
    .pio/build/native/program.exe
    ```
+   If you're on Windows:
+   ```bash
+   .pio\build\native\program.exe
+   ```
+   
 
 ---
 


### PR DESCRIPTION
While trying to run a SITL test, I noticed the file path uses backslashes for Windows as opposed to forward slashes on Unix-type systems. I've added a small message to guide users as such based on their OS.